### PR TITLE
PublisherCoordinatorReport: Avoid tracking publishers.

### DIFF
--- a/tests/publishers/test_coordinator.py
+++ b/tests/publishers/test_coordinator.py
@@ -24,13 +24,13 @@ from mobilizon_reshare.publishers.coordinator import (
         [[PublicationStatus.COMPLETED], True],
     ],
 )
-def test_publication_report_successful(statuses, successful):
+def test_publication_report_successful(
+    statuses: list[PublicationStatus], successful: bool
+):
     reports = {}
     for i, status in enumerate(statuses):
-        reports[UUID(int=i)] = PublicationReport(
-            reason=None, publication_id=None, status=status
-        )
-    assert PublisherCoordinatorReport(None, reports).successful == successful
+        reports[UUID(int=i)] = PublicationReport(reason="", status=status)
+    assert PublisherCoordinatorReport(reports).successful == successful
 
 
 @pytest.fixture
@@ -113,17 +113,14 @@ async def test_notifier_coordinator_publication_failed(
     mock_send = MagicMock()
     mock_publisher_valid._send = mock_send
     report = PublisherCoordinatorReport(
-        {UUID(int=1): mock_publisher_valid, UUID(int=2): mock_publisher_valid},
         {
             UUID(int=1): PublicationReport(
                 status=PublicationStatus.FAILED,
                 reason="some failure",
-                publication_id=UUID(int=1),
             ),
             UUID(int=2): PublicationReport(
                 status=PublicationStatus.FAILED,
                 reason="some failure",
-                publication_id=UUID(int=2),
             ),
         },
     )

--- a/tests/storage/test_update.py
+++ b/tests/storage/test_update.py
@@ -75,15 +75,12 @@ async def test_update_publishers(
                     UUID(int=3): PublicationReport(
                         status=PublicationStatus.FAILED,
                         reason="Invalid credentials",
-                        publication_id=UUID(int=3),
                     ),
                     UUID(int=4): PublicationReport(
                         status=PublicationStatus.COMPLETED,
                         reason="",
-                        publication_id=UUID(int=4),
                     ),
                 },
-                publishers={},
             ),
             MobilizonEvent(
                 name="event_1",


### PR DESCRIPTION
This patch does two things (which I should've pointed out in #52 , sorry about that :( ):

1. Remove the `publication_id` from a `PublicationReport`. `PublicationReport`s are always accessed through a `PublisherCoordinatorReport` which already binds `publication_id`s and `PublicationReport`s.
2. Remove the `publishers` field from a `PublisherCoordinatorReport`. All the information we need about publishers is already expressed by the publication id. If that's not the case, we should probably track more in the model.