### PR TITLE
add pytest coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 mobilizon-reshare="mobilizon_reshare.cli.cli:mobilizon_reshare"
+
+[tool.pytest.ini_options]
+addopts = "--cov-config=.coveragerc --cov=. --cov-report html tests/"


### PR DESCRIPTION
configured pytest to:
execute tests, generate coverage data, create a coverage html report.

added .coveragerc to ignore specific paths from coverage data, for now only "tests/"