### PR TITLE
scripts: Add mobilizon-reshare.sh.

### DIFF
--- a/mobilizon_reshare/config/config.py
+++ b/mobilizon_reshare/config/config.py
@@ -1,5 +1,4 @@
 import importlib.resources
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -63,7 +62,6 @@ def build_settings(
     ) as bundled_settings_path:
         for f in [
             settings_file,
-            os.environ.get("MOBILIZION_RESHARE_SETTINGS_FILE"),
             Path(dirs.user_config_dir, "mobilizon_reshare.toml"),
             Path(dirs.site_config_dir, "mobilizon_reshare.toml"),
             bundled_settings_path,

--- a/scripts/mobilizon-reshare.sh
+++ b/scripts/mobilizon-reshare.sh
@@ -2,9 +2,8 @@
 
 export MOBILIZON_RESHARE_LOG_DIR="/tmp"
 export MOBILIZON_RESHARE_LOCAL_STATE_DIR="/tmp"
-export PYTHONPATH="$(pwd):${PYTHONPATH}"
 export SECRETS_FOR_DYNACONF="$(pwd)/.secrets.toml"
 export SETTINGS_FILE_FOR_DYNACONF="$(pwd)/mobilizon_reshare.toml"
 export ENV_FOR_DYNACONF="production"
 
-python "$(pwd)/mobilizon_reshare/cli/cli.py" "$@"
+poetry run mobilizon-reshare "$@"

--- a/scripts/mobilizon-reshare.sh
+++ b/scripts/mobilizon-reshare.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export MOBILIZON_RESHARE_LOG_DIR="/tmp"
+export MOBILIZON_RESHARE_LOCAL_STATE_DIR="/tmp"
+export PYTHONPATH="$(pwd):${PYTHONPATH}"
+export SECRETS_FOR_DYNACONF="$(pwd)/.secrets.toml"
+export SETTINGS_FILE_FOR_DYNACONF="$(pwd)/mobilizon_reshare.toml"
+export ENV_FOR_DYNACONF="production"
+
+python "$(pwd)/mobilizon_reshare/cli/cli.py" "$@"


### PR DESCRIPTION
This script lets you run mobilizon-reshare commands from your git
checkout. This is very useful for debugging new features or in general
just to have a quick feedback loop from your modifications.

Example usage:

$ scripts/mobilizon-reshare.sh inspect all