### PR TITLE
add intermediate variable since aerich doesn't play nice with functions as configuration entrypoint

### DIFF
--- a/mobilizon_reshare/storage/db.py
+++ b/mobilizon_reshare/storage/db.py
@@ -41,6 +41,9 @@ def get_tortoise_orm():
     }
 
 
+TORTOISE_ORM = get_tortoise_orm()
+
+
 class MoReDB:
     def __init__(self, path: Path):
         self.path = path


### PR DESCRIPTION
in order to keep tortoiseorm in a function and make aerich work, it was necessary to save a result of function call to variable and use that variable for aerich init/configuration phases.