### PR TITLE
Ci run tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-          poetry install
+        run: scripts/install_github_actions_dev_dependencies.sh
       - name: Run tests in dev env
         run: poetry run pytest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,7 @@ name: CI
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    tags:
-      - v*
+    branches: ["master"]
 
 
   # Allows you to run this workflow manually from the Actions tab
@@ -16,7 +15,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  run-tests-dev:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -25,43 +24,32 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Runs a single command using the runners shell
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+      - name: Run tests in dev env
+        run: poetry run pytest
+
+  run-tests-preprod:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
 
       # Runs a single command using the runners shell
       - name: Install GNU Guix
         uses: PromyLOPh/guix-install-action@v1
 
       # Runs a set of commands using the runners shell
-      - name: Build image
-        run: scripts/build_docker_image.sh
-      - name: Upload pack (Docker)
-        uses: actions/upload-artifact@v2
-        with:
-          name: mobilizon-reshare-docker
-          path: docker-image.tar.gz
-  publish:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    needs: build
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - name: Get release tag
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
-      - name: Download image
-        uses: actions/download-artifact@v2
-        with:
-          name: mobilizon-reshare-docker
-
-      - name: Publish to Docker Hub
-        uses: fishinthecalculator/publish-docker-image-action@v0.1.3
-        env:
-          IMAGE_TAG: ${{ steps.vars.outputs.tag }}
-        with:
-          name: fishinthecalculator/mobilizon-reshare
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          image: docker-image.tar.gz
+      - name: Run tests in preprod env
+        run: guix time-machine -C channels-lock.scm -- build -L . mobilizon-reshare.git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Publish release to Docker Hub
+
+# Controls when the workflow will run
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - v*
+
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+
+      # Runs a single command using the runners shell
+      - name: Install GNU Guix
+        uses: PromyLOPh/guix-install-action@v1
+
+      # Runs a set of commands using the runners shell
+      - name: Build image
+        run: scripts/build_docker_image.sh
+      - name: Upload pack (Docker)
+        uses: actions/upload-artifact@v2
+        with:
+          name: mobilizon-reshare-docker
+          path: docker-image.tar.gz
+  publish:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    needs: build
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Get release tag
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: mobilizon-reshare-docker
+
+      - name: Publish to Docker Hub
+        uses: fishinthecalculator/publish-docker-image-action@v0.1.3
+        env:
+          IMAGE_TAG: ${{ steps.vars.outputs.tag }}
+        with:
+          name: fishinthecalculator/mobilizon-reshare
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          image: docker-image.tar.gz

--- a/scripts/install_github_actions_dev_dependencies.sh
+++ b/scripts/install_github_actions_dev_dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+python -m pip install --upgrade pip
+pip install poetry
+poetry install


### PR DESCRIPTION
This patch separates the release workflow (build and publish a Docker image) from the main workflow (run the test suite for every PR merged to master)