### PR TITLE
scheduler.py: Fix intervals.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       SECRETS_FOR_DYNACONF: /etc/xdg/mobilizon-reshare/0.2.0/.secrets.toml
       ENV_FOR_DYNACONF: production
-      MOBILIZON_RESHARE_INTERVAL: "*/15 10-18 * * 1-5"
+      MOBILIZON_RESHARE_INTERVAL: "*/15 10-18 * * 0-4"
     volumes:
       - ./.secrets.toml:/etc/xdg/mobilizon-reshare/0.2.0/.secrets.toml:ro
       - ./mobilizon_reshare.toml:/etc/xdg/mobilizon-reshare/0.2.0/mobilizon_reshare.toml:ro

--- a/scripts/scheduler.py
+++ b/scripts/scheduler.py
@@ -23,14 +23,14 @@ sched = AsyncIOScheduler()
 sched.add_job(
     partial(_safe_execution, start),
     CronTrigger.from_crontab(
-        os.environ.get("MOBILIZON_RESHARE_INTERVAL", "*/15 10-18 * * 1-5")
+        os.environ.get("MOBILIZON_RESHARE_INTERVAL", "*/15 10-18 * * 0-4")
     ),
 )
 # Runs "recap" once a week
 sched.add_job(
     partial(_safe_execution, recap),
     CronTrigger.from_crontab(
-        os.environ.get("MOBILIZON_RESHARE_RECAP_INTERVAL", "5 11 * * 1")
+        os.environ.get("MOBILIZON_RESHARE_RECAP_INTERVAL", "5 11 * * 0")
     ),
 )
 sched.start()


### PR DESCRIPTION
APScheduler uses 0-indexed week days.